### PR TITLE
Feat/week compose1 Android UI 기초 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -55,6 +55,8 @@ dependencies {
     implementation 'androidx.compose.ui:ui-graphics'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material3:material3'
+    implementation 'androidx.compose.ui:ui-tooling-preview-android:1.6.4'
+    implementation 'androidx.navigation:navigation-compose:2.7.7'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,9 +13,14 @@
         android:theme="@style/Theme.NOWSOPTAndroid"
         tools:targetApi="31">
         <activity
-            android:name=".MainActivity"
+            android:name=".SignUpActivity"
+            android:exported="false"
+            android:label="@string/title_activity_sign_up"
+            android:theme="@style/Theme.NOWSOPTAndroid" />
+        <activity
+            android:name=".LoginActivity"
             android:exported="true"
-            android:label="@string/app_name"
+            android:label="@string/title_activity_login"
             android:theme="@style/Theme.NOWSOPTAndroid">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -23,6 +28,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".MainActivity"
+            android:exported="false"
+            android:label="@string/app_name"
+            android:theme="@style/Theme.NOWSOPTAndroid" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/sopt/now/compose/LoginActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/LoginActivity.kt
@@ -1,0 +1,110 @@
+package com.sopt.now.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.compose.rememberNavController
+import com.sopt.now.compose.ui.theme.NOWSOPTAndroidTheme
+
+class LoginActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NOWSOPTAndroidTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    val navController = rememberNavController()
+                    LoginScreen()
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun LoginScreen() {
+    var userId by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(30.dp)
+    ) {
+        Text(
+            text = "Welcome to SOPT",
+            fontSize = 28.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 50.dp)
+            )
+        Text(
+            text="ID",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = userId,
+            onValueChange = { userId = it },
+            label = { Text("아이디를 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+        Text(
+            text="비밀번호",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = password,
+            onValueChange = { password = it },
+            label = { Text("비밀번호를 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = {  },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 12.dp)) {
+            Text(text = "로그인 하기")
+        }
+
+        Button(
+            onClick = {  },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 30.dp)) {
+            Text(text = "회원가입 하기")
+        }
+    }
+}

--- a/app/src/main/java/com/sopt/now/compose/LoginActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/LoginActivity.kt
@@ -1,8 +1,13 @@
 package com.sopt.now.compose
 
+import android.app.Activity
+import android.app.Activity.RESULT_OK
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,6 +15,9 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -17,14 +25,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.compose.rememberNavController
 import com.sopt.now.compose.ui.theme.NOWSOPTAndroidTheme
+import kotlinx.coroutines.launch
 
 class LoginActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -35,7 +46,6 @@ class LoginActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    val navController = rememberNavController()
                     LoginScreen()
                 }
             }
@@ -47,64 +57,117 @@ class LoginActivity : ComponentActivity() {
 @Composable
 fun LoginScreen() {
     var userId by remember { mutableStateOf("") }
-    var password by remember { mutableStateOf("") }
+    var userPw by remember { mutableStateOf("") }
+    var nickname by remember { mutableStateOf("") }
+    var mbti by remember { mutableStateOf("") }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(30.dp)
-    ) {
-        Text(
-            text = "Welcome to SOPT",
-            fontSize = 28.sp,
-            textAlign = TextAlign.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 50.dp)
-            )
-        Text(
-            text="ID",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = userId,
-            onValueChange = { userId = it },
-            label = { Text("아이디를 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
-        Text(
-            text="비밀번호",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = password,
-            onValueChange = { password = it },
-            label = { Text("비밀번호를 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
+    var id by remember { mutableStateOf("") }
+    var pw by remember { mutableStateOf("") }
 
-        Spacer(modifier = Modifier.weight(1f))
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
 
-        Button(
-            onClick = {  },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 12.dp)) {
-            Text(text = "로그인 하기")
+    val context = LocalContext.current
+
+    val launcher =
+        rememberLauncherForActivityResult(contract = ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == RESULT_OK) {
+                val data = result.data
+
+                userId = data?.getStringExtra("userId").toString()
+                userPw = data?.getStringExtra("password").toString()
+                nickname = data?.getStringExtra("nickname").toString()
+                mbti = data?.getStringExtra("mbti").toString()
+            }
         }
 
-        Button(
-            onClick = {  },
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 30.dp)) {
-            Text(text = "회원가입 하기")
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(30.dp)
+        ) {
+            Text(
+                text = "Welcome to SOPT",
+                fontSize = 28.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 50.dp)
+            )
+            Text(
+                text = "ID",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp)
+            )
+            TextField(
+                value = id,
+                onValueChange = { id = it },
+                label = { Text("아이디를 입력해주세요") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+            Text(
+                text = "비밀번호",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp)
+            )
+            TextField(
+                value = pw,
+                onValueChange = { pw = it },
+                label = { Text("비밀번호를 입력해주세요") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = {
+                    if (userId == id && userPw == pw && userId != "" && userPw != "") {
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar("로그인 성공")
+                        }
+                        val intent = Intent(context, MainActivity::class.java)
+
+                        intent.putExtra("userId", userId)
+                        intent.putExtra("password", userPw)
+                        intent.putExtra("nickname", nickname)
+                        intent.putExtra("mbti", mbti)
+
+                        (context as? Activity)?.setResult(RESULT_OK, intent)
+                        (context as? Activity)?.finish()
+
+                        context.startActivity(intent)
+                    } else {
+                        coroutineScope.launch {
+                            snackbarHostState.showSnackbar("아이디 또는 비밀번호가 일치하지 않습니다")
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(text = "로그인 하기")
+            }
+
+            Button(
+                onClick = {
+                    launcher.launch(Intent(context, SignUpActivity::class.java))
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+            ) {
+                Text(text = "회원가입 하기")
+            }
         }
     }
 }

--- a/app/src/main/java/com/sopt/now/compose/MainActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/MainActivity.kt
@@ -3,13 +3,27 @@ package com.sopt.now.compose
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.sopt.now.compose.ui.theme.NOWSOPTAndroidTheme
 
 class MainActivity : ComponentActivity() {
@@ -17,30 +31,74 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             NOWSOPTAndroidTheme {
-                // A surface container using the 'background' color from the theme
                 Surface(
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("Android")
+                    Main(
+                        intent.getStringExtra("userId"),
+                        intent.getStringExtra("password"),
+                        intent.getStringExtra("nickname"),
+                        intent.getStringExtra("mbti")
+                    )
                 }
             }
         }
     }
 }
 
+
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
+fun Main(userId: String?, password: String?, nickname: String?, mbti: String?) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = Modifier.padding(30.dp)
+    ) {
+        Row (
+            verticalAlignment = Alignment.CenterVertically
+        ){
+            Image(
+                painter = painterResource(
+                    id = R.drawable.ic_launcher_background),
+                    contentDescription = "profile"
+            )
+            Text(
+                text = "$nickname",
+                fontSize = 20.sp,
+                modifier = Modifier.padding(start = 16.dp)
+            )
+        }
+        Text(
+            text = "ID",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 20.dp)
+        )
+        Text(
+            text = "$userId",
+            fontSize = 20.sp)
+        Text(
+            text = "비밀번호",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 20.dp)
+        )
+        Text(
+            text = "$password",
+            fontSize = 20.sp)
+        Text(
+            text = "MBTI",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 20.dp)
+        )
+        Text(
+            text = "$mbti",
+            fontSize = 20.sp)
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
-fun GreetingPreview() {
+fun DefaultPreview() {
     NOWSOPTAndroidTheme {
-        Greeting("Android")
+        Main("userId", "password", "nickname", "mbti")
     }
 }

--- a/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
@@ -1,5 +1,7 @@
 package com.sopt.now.compose
 
+import android.app.Activity
+import android.app.Activity.RESULT_OK
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -163,7 +165,15 @@ fun SignUp() {
                                 duration = SnackbarDuration.Long)
                             }
 
-                            context.startActivity(Intent(context, LoginActivity::class.java))
+                            val intent = Intent(context, LoginActivity::class.java).apply {
+                                putExtra("userId", userId)
+                                putExtra("password", password)
+                                putExtra("nickname", nickname)
+                                putExtra("mbti", mbti)
+                            }
+
+                            (context as? Activity)?.setResult(RESULT_OK, intent)
+                            (context as? Activity)?.finish()
                         }
                     }
                 },

--- a/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
@@ -179,7 +179,7 @@ fun SignUp() {
                 },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 12.dp, bottom = 12.dp)) {
+                    .padding(top = 16.dp)) {
                 Text(text = "회원가입 하기")
             }
         }

--- a/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
@@ -1,0 +1,125 @@
+package com.sopt.now.compose
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.sopt.now.compose.ui.theme.NOWSOPTAndroidTheme
+
+class SignUpActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            NOWSOPTAndroidTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    SignUp()
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun SignUp() {
+    var userId by remember { mutableStateOf("") }
+    var password by remember { mutableStateOf("") }
+    var nickname by remember { mutableStateOf("") }
+    var mbti by remember { mutableStateOf("") }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(30.dp)
+    ) {
+        Text(
+            text = "Sign Up",
+            fontSize = 28.sp,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Text(
+            text="ID",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = userId,
+            onValueChange = {userId = it},
+            label = { Text("아이디를 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+        Text(
+            text="비밀번호",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = password,
+            onValueChange = {password = it},
+            label = { Text("비밀번호를 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+        Text(
+            text="닉네임",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = nickname,
+            onValueChange = {nickname = it},
+            label = { Text("닉네임을 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+        Text(
+            text="MBTI",
+            fontSize = 24.sp,
+            modifier = Modifier.padding(top = 30.dp)
+        )
+        TextField(
+            value = mbti,
+            onValueChange = {mbti = it},
+            label = { Text("MBTI를 입력해주세요") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 12.dp)
+        )
+        Spacer(modifier = Modifier.weight(1f))
+
+        Button(
+            onClick = {  },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 30.dp)) {
+            Text(text = "회원가입 하기")
+        }
+    }
+}

--- a/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
+++ b/app/src/main/java/com/sopt/now/compose/SignUpActivity.kt
@@ -1,5 +1,6 @@
 package com.sopt.now.compose
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +11,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -17,13 +22,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.sopt.now.compose.ui.theme.NOWSOPTAndroidTheme
+import kotlinx.coroutines.launch
 
 class SignUpActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -49,77 +58,121 @@ fun SignUp() {
     var nickname by remember { mutableStateOf("") }
     var mbti by remember { mutableStateOf("") }
 
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(30.dp)
-    ) {
-        Text(
-            text = "Sign Up",
-            fontSize = 28.sp,
-            textAlign = TextAlign.Center,
-            modifier = Modifier.fillMaxWidth()
-        )
-        Text(
-            text="ID",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = userId,
-            onValueChange = {userId = it},
-            label = { Text("아이디를 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
-        Text(
-            text="비밀번호",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = password,
-            onValueChange = {password = it},
-            label = { Text("비밀번호를 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
-        Text(
-            text="닉네임",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = nickname,
-            onValueChange = {nickname = it},
-            label = { Text("닉네임을 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
-        Text(
-            text="MBTI",
-            fontSize = 24.sp,
-            modifier = Modifier.padding(top = 30.dp)
-        )
-        TextField(
-            value = mbti,
-            onValueChange = {mbti = it},
-            label = { Text("MBTI를 입력해주세요") },
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 12.dp)
-        )
-        Spacer(modifier = Modifier.weight(1f))
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
 
-        Button(
-            onClick = {  },
+    Scaffold(
+        snackbarHost = { SnackbarHost(hostState = snackbarHostState) }
+    ) { innerPadding ->
+        Column(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 30.dp)) {
-            Text(text = "회원가입 하기")
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(30.dp)
+        ) {
+            Text(
+                text = "Sign Up",
+                fontSize = 28.sp,
+                textAlign = TextAlign.Center,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(
+                text="ID",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp)
+            )
+            TextField(
+                value = userId,
+                onValueChange = {userId = it},
+                label = { Text("아이디를 입력해주세요") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+            Text(
+                text="비밀번호",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp),
+            )
+            TextField(
+                value = password,
+                onValueChange = {password = it},
+                label = { Text("비밀번호를 입력해주세요") },
+                visualTransformation = PasswordVisualTransformation(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+            Text(
+                text="닉네임",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp)
+            )
+            TextField(
+                value = nickname,
+                onValueChange = {nickname = it},
+                label = { Text("닉네임을 입력해주세요") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+            Text(
+                text="MBTI",
+                fontSize = 24.sp,
+                modifier = Modifier.padding(top = 30.dp)
+            )
+            TextField(
+                value = mbti,
+                onValueChange = {mbti = it},
+                label = { Text("MBTI를 입력해주세요") },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp)
+            )
+            Spacer(modifier = Modifier.weight(1f))
+
+            Button(
+                onClick = {
+                    when {
+                        userId.length !in 6..10 -> {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                "아이디는 6자 이상 10자 이하여야 합니다",
+                                duration = SnackbarDuration.Short)
+                            }
+                        }
+                        password.length !in 8..12 -> {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                "비밀번호는 8자 이상 16자 이하여야 합니다",
+                                duration = SnackbarDuration.Short)
+                            }
+                        }
+                        nickname.isBlank() -> {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                "닉네임을 입력해주세요",
+                                duration = SnackbarDuration.Short)
+                            }
+                        }
+                        else -> {
+                            coroutineScope.launch {
+                                snackbarHostState.showSnackbar(
+                                "회원가입 성공",
+                                duration = SnackbarDuration.Long)
+                            }
+
+                            context.startActivity(Intent(context, LoginActivity::class.java))
+                        }
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 12.dp, bottom = 12.dp)) {
+                Text(text = "회원가입 하기")
+            }
         }
     }
 }
+

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">NOW SOPT Android</string>
+    <string name="title_activity_login">LoginActivity</string>
+    <string name="title_activity_sign_up">SignUpActivity</string>
+    <string name="title_activity_login_activity.kt">LoginActivity.kt</string>
 </resources>


### PR DESCRIPTION
## 📌𝘐𝘴𝘴𝘶𝘦𝘴
closed #3 

## 📎𝘞𝘰𝘳𝘬 𝘋𝘦𝘴𝘤𝘳𝘪𝘱𝘵𝘪𝘰𝘯
> **로그인 화면 (LoginActivity)**
- 로그인 하기 버튼 아래에 회원가입 버튼 추가
- 비밀번호는 EditText의 InputType 활용해서 안 보이게 설정
- 회원가입 버튼 누르면 회원가입 화면으로 이동
- ID, Password 일치 하면 로그인 성공 토스트 보여주기 
- 메인으로 id, password, nickname 값 저장해서 이동

> **회원가입 화면 (SignupActivity)**
- ID, Password, 닉네임 필수 입력 (ID: 6부터10, Password 8부터12, 닉네임: 한글자 이상, 공백일 경우 메시지 출력)
- 한가지 이상 조건 추가 : TextField로 MBTI 추가
- 모든 정보를 입력하지 않았을 경우 회원가입 불가능 메세지 출력 (SnackBar)
- 회원가입 성공하면 LoginActivity로 전환 + 정보 전달
- 회원가입 성공 메세지 알려주기

> **메인 페이지 (MainActivity)**
- 로그인 화면에서 받아온 닉네임과 ID 사용


## 📷𝘚𝘤𝘳𝘦𝘦𝘯𝘴𝘩𝘰𝘵
<img src="https://github.com/NOW-SOPT-ANDROID/seohee-yoon/assets/102652293/c0ee15dc-7a84-4f96-8bfd-36dfa5d0e7d9" width="360"/>


## 💬𝘛𝘰 𝘙𝘦𝘷𝘪𝘦𝘸𝘦𝘳𝘴
navController 이용해서 화면 전환을 할 수 있던데, 하다가 포기했습니다..
다른 activity로 전환이 어렵던데 혹시 하신 분 있다면 알려주시면 감사하겠습니다 🙇  